### PR TITLE
Skip overwriting existing service definition

### DIFF
--- a/src/DependencyInjection/Compiler/RegisterControllersPass.php
+++ b/src/DependencyInjection/Compiler/RegisterControllersPass.php
@@ -59,16 +59,12 @@ final class RegisterControllersPass implements CompilerPassInterface
         foreach ($controllers as $controller) {
             $id = $this->buildControllerIdFromClass($controller);
 
-            if (!$containerBuilder->hasDefinition($id))
-            {
+            if (!$containerBuilder->hasDefinition($id)) {
                 $definition = $this->buildControllerDefinitionFromClass($controller);
-            }
-            else
-            {
+            } else {
                 $definition = $containerBuilder->getDefinition($id);
                 $definition->setAutowired(true);
             }
-
 
             $containerBuilder->setDefinition($id, $definition);
             $this->controllerClassMap->addController($id, $controller);

--- a/src/DependencyInjection/Compiler/RegisterControllersPass.php
+++ b/src/DependencyInjection/Compiler/RegisterControllersPass.php
@@ -58,7 +58,17 @@ final class RegisterControllersPass implements CompilerPassInterface
     {
         foreach ($controllers as $controller) {
             $id = $this->buildControllerIdFromClass($controller);
-            $definition = $this->buildControllerDefinitionFromClass($controller);
+
+            if (!$containerBuilder->hasDefinition($id))
+            {
+                $definition = $this->buildControllerDefinitionFromClass($controller);
+            }
+            else
+            {
+                $definition = $containerBuilder->getDefinition($id);
+                $definition->setAutowired(true);
+            }
+
 
             $containerBuilder->setDefinition($id, $definition);
             $this->controllerClassMap->addController($id, $controller);

--- a/tests/DependencyInjection/Compiler/RegisterControllersPassTest.php
+++ b/tests/DependencyInjection/Compiler/RegisterControllersPassTest.php
@@ -61,7 +61,8 @@ final class RegisterControllersPassTest extends PHPUnit_Framework_TestCase
 
         $controllerDefition = new Definition(SomeController::class);
         $containerBuilder->setDefinition(
-            'symplify.controllerautowire.tests.dependencyinjection.compiler.registercontrollerspasssource.somecontroller',
+            'symplify.controllerautowire.tests.dependencyinjection.'
+                . 'compiler.registercontrollerspasssource.somecontroller',
             $controllerDefition
         );
         $this->assertCount(1, $containerBuilder->getDefinitions());

--- a/tests/DependencyInjection/Compiler/RegisterControllersPassTest.php
+++ b/tests/DependencyInjection/Compiler/RegisterControllersPassTest.php
@@ -49,4 +49,26 @@ final class RegisterControllersPassTest extends PHPUnit_Framework_TestCase
         $this->assertSame(SomeController::class, $controllerDefinition->getClass());
         $this->assertTrue($controllerDefinition->isAutowired());
     }
+
+    public function testServiceDefinitionExists()
+    {
+        $containerBuilder = new ContainerBuilder();
+        $containerBuilder->prependExtensionConfig(SymplifyControllerAutowireBundle::ALIAS, [
+            'controller_dirs' => [
+                __DIR__.'/RegisterControllersPassSource',
+            ],
+        ]);
+
+        $controllerDefition = new Definition(SomeController::class);
+        $containerBuilder->setDefinition(
+            'symplify.controllerautowire.tests.dependencyinjection.compiler.registercontrollerspasssource.somecontroller',
+            $controllerDefition
+        );
+        $this->assertCount(1, $containerBuilder->getDefinitions());
+
+        $this->registerControllersPass->process($containerBuilder);
+        $this->assertCount(1, $containerBuilder->getDefinitions());
+
+        $this->assertTrue($controllerDefition->isAutowired());
+    }
 }

--- a/tests/DependencyInjection/Compiler/RegisterControllersPassTest.php
+++ b/tests/DependencyInjection/Compiler/RegisterControllersPassTest.php
@@ -62,7 +62,7 @@ final class RegisterControllersPassTest extends PHPUnit_Framework_TestCase
         $controllerDefition = new Definition(SomeController::class);
         $containerBuilder->setDefinition(
             'symplify.controllerautowire.tests.dependencyinjection.'
-                . 'compiler.registercontrollerspasssource.somecontroller',
+                .'compiler.registercontrollerspasssource.somecontroller',
             $controllerDefition
         );
         $this->assertCount(1, $containerBuilder->getDefinitions());


### PR DESCRIPTION
Hello,
this PR disables overwriting of existing services definition and just sets autowire option to true.

This is very usefull when you want to pass e.g. scalar parametrs from parameters.yml into controller because in SF 2.8.3 you can do:

```
controller_service:
    class: SomeController
    arguments:
        - ''
        - %scalar_parametr%
```

And in upcomming SF 2.8.4:
```
controller_service:
    class: SomeController
    arguments:
        1: %scalar_parametr%
```

So the first parametr is autowired and the second is not